### PR TITLE
Smbtestcasesvisible

### DIFF
--- a/microsoft/testsuites/xfstests/xfstesting.py
+++ b/microsoft/testsuites/xfstests/xfstesting.py
@@ -115,7 +115,7 @@ def _deploy_azure_file_share(
     names: Dict[str, str],
     azure_file_share: Union[AzureFileShare, Nfs],
     allow_shared_key_access: bool = True,
-    enable_private_endpoint: bool = True,
+    enable_private_endpoint: bool = False,
     storage_account_sku: str = "Premium_LRS",
     storage_account_kind: str = "FileStorage",
     file_share_quota_in_gb: int = 100,

--- a/runbooks/azfiles_xfstests.yml
+++ b/runbooks/azfiles_xfstests.yml
@@ -49,7 +49,7 @@ variable:
     is_case_visible: true
     value: ""
   - name: smb_testcases
-    is_case_visible: true
+    is_case_visible: false
     value: ""
   - name: source_address_prefixes
     value: ["4.194.0.0/16"]


### PR DESCRIPTION
To selectively run testcases, smb_testcases should be visible. If all tests need to run, is_case_visible should be set to false. 